### PR TITLE
Add CK550v2 to constants file

### DIFF
--- a/src/Constants.swift
+++ b/src/Constants.swift
@@ -31,4 +31,5 @@ let keyboardVID: Int = 0x2516
 enum KeyboardPIDs: Int, CaseIterable {
     case CK550 = 0x007f; // Works - @vookimedlo - this is the only keyboard I have, any contribution for other models is welcome!!!
     case CK530 = 0x009f; // Works - @cscheib - suggested & reported - Thanks!!!
+    case CK550v2 = 0x0145; // Works - @adrewb - CK550v2 Version 1.10 model #: GK-550-GKTM1-US
 }


### PR DESCRIPTION
Version 2 of CK550 Product ID.

```
                CK550 V2 Gaming Mechanical Keyboard:

                  Product ID: 0x0145
                  Vendor ID: 0x2516
                  Version: 1.10
                  Speed: Up to 12 Mb/s
                  Manufacturer: COOLER MASTER
                  Location ID: 0x00133000 / 7
                  Current Available (mA): 500
                  Current Required (mA): 100
                  Extra Operating Current (mA): 0
```